### PR TITLE
Feat update jscodeshiftExecutable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # changelog
 
+## 0.1.2
+
+- Feat: update jscodeshift executable path.
+
 ## 0.1.1
 
 - Feat: add typings.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@appworks/codemod",
   "description": "AppWorks codemod scripts",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "keywords": [
     "appworks",
     "codemod",

--- a/src/executeTransforms.js
+++ b/src/executeTransforms.js
@@ -3,7 +3,9 @@ const execa = require('execa');
 const { getProjectType, getProjectFramework, getProjectLanguageType } = require('@appworks/project-utils');
 const config = require('../transforms/config.json');
 
-const jscodeshiftExecutable = require.resolve('.bin/jscodeshift');
+// Use 'jscodeshift/bin/jscodeshift' instead '.bin/jscodeshift'
+// For VS Code Extension environment which has been deleted '.bin/jscodeshift' by vsce
+const jscodeshiftExecutable = require.resolve('jscodeshift/bin/jscodeshift');
 
 async function executeTransforms(cwd, files, transforms, mode, jscodeshiftAgs) {
   // Add project info to transform option

--- a/src/executeTransforms.js
+++ b/src/executeTransforms.js
@@ -3,8 +3,9 @@ const execa = require('execa');
 const { getProjectType, getProjectFramework, getProjectLanguageType } = require('@appworks/project-utils');
 const config = require('../transforms/config.json');
 
-// Use 'jscodeshift/bin/jscodeshift' instead '.bin/jscodeshift'
+// Using 'jscodeshift/bin/jscodeshift' instead of '.bin/jscodeshift'
 // For VS Code Extension environment which has been deleted '.bin/jscodeshift' by vsce
+// By the way '!node_modules/.bin/jscodeshift' in .vsceignore doesn't work
 const jscodeshiftExecutable = require.resolve('jscodeshift/bin/jscodeshift');
 
 async function executeTransforms(cwd, files, transforms, mode, jscodeshiftAgs) {


### PR DESCRIPTION
Using 'jscodeshift/bin/jscodeshift' instead of '.bin/jscodeshift'
For VS Code Extension environment which has been deleted '.bin/jscodeshift' by vsce
By the way '!node_modules/.bin/jscodeshift' in .vsceignore doesn't work