### PR TITLE
Feat add lint-config-to-spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # changelog
 
+## 0.1.3
+
+- Feat: add transform - `lint-config-to-spec`
 ## 0.1.2
 
 - Feat: update jscodeshift executable path.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # changelog
 
-## 0.1.3
+## 0.2.0
 
 - Feat: add transform - `lint-config-to-spec`
+- Feat: Update check mode, return all codemods that can run in your project
 ## 0.1.2
 
 - Feat: update jscodeshift executable path.

--- a/README.md
+++ b/README.md
@@ -117,3 +117,7 @@ interface IResult {
 ### 1. `plugin-rax-component-to-component`
 
 Update `plugin-rax-component` to `plugin-component`. [docs](./transforms/docs/plugin-rax-component-to-component.md)
+
+### 2. `lint-config-to-spec`
+
+Follow Alibaba FED lint rules, and use `@iceworks/spec` best practices. [docs](./transforms/docs/lint-config-to-spec.md)

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@appworks/project-utils": "^0.1.0",
+    "ejs": "^3.1.6",
     "execa": "^5.1.1",
     "glob": "^7.1.7",
     "jscodeshift": "^0.11.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@appworks/codemod",
   "description": "AppWorks codemod scripts",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "keywords": [
     "appworks",
     "codemod",

--- a/src/executeTransforms.js
+++ b/src/executeTransforms.js
@@ -44,10 +44,8 @@ async function executeTransforms(cwd, files, transforms, mode, jscodeshiftAgs) {
 
         if (
           mode === 'run' ||
-          // check mode return can run codemods when
-          // 1. jscodeshift show not 0 ok if matched
-          // 2. codemod which severity >= 1
-          (!/\n0 ok\n/.test(output) && transformConfig.severity >= 1)
+          // check mode return can run codemods when jscodeshift running ok and show changed count
+          (/ok\n/.test(output) && !/\n0 ok\n/.test(output))
         ) {
           resolve({
             ...transformConfig,

--- a/transforms/README.md
+++ b/transforms/README.md
@@ -4,7 +4,7 @@
 
 要标准化 transform 输出，codemod 未命中或不需要运行时请 return null，命中时才 return 修改后内容。
 
-**注意：不能所有都 return 文件内容！会影响 check 方法结果！**
+**注意：不能所有都 return 文件内容！会影响 check 方法结果！写文件的操作必须判断 `options.dry !== true`**
 
 ## 2. 入参说明
 

--- a/transforms/config.json
+++ b/transforms/config.json
@@ -6,5 +6,12 @@
     "message_en": "upgrade from plugin-rax-component to plugin-component",
     "severity": 1,
     "npm_deprecate": "build-plugin-rax-component"
+  },
+  "lint-config-to-spec": {
+    "title": "遵循阿里巴巴前端规范，并接入 @iceworks/spec 的最佳实践",
+    "title_en": "Follow Alibaba FED lint rules, and use @iceworks/spec best practices",
+    "message": "遵循阿里巴巴前端规范，并更新 rax, ice 和 react 项目中的 eslint / stylelint / prettier 配置。",
+    "message_en": "Follow Alibaba FED lint rules, and update eslint / stylelint / prettier in rax, ice and react project.",
+    "severity": 1
   }
 }

--- a/transforms/config.json
+++ b/transforms/config.json
@@ -12,6 +12,7 @@
     "title_en": "Follow Alibaba FED lint rules, and use @iceworks/spec best practices",
     "message": "遵循阿里巴巴前端规范，并更新 rax, ice 和 react 项目中的 eslint / stylelint / prettier 配置。",
     "message_en": "Follow Alibaba FED lint rules, and update eslint / stylelint / prettier in rax, ice and react project.",
-    "severity": 1
+    "severity": 1,
+    "npm_deprecate": "@ice/spec"
   }
 }

--- a/transforms/config.json
+++ b/transforms/config.json
@@ -12,7 +12,7 @@
     "title_en": "Follow Alibaba FED lint rules, and use @iceworks/spec best practices",
     "message": "遵循阿里巴巴前端规范，并更新 rax, ice 和 react 项目中的 eslint / stylelint / prettier 配置。",
     "message_en": "Follow Alibaba FED lint rules, and update eslint / stylelint / prettier in rax, ice and react project.",
-    "severity": 1,
+    "severity": 0,
     "npm_deprecate": "@ice/spec"
   }
 }

--- a/transforms/docs/lint-config-to-spec.md
+++ b/transforms/docs/lint-config-to-spec.md
@@ -1,0 +1,55 @@
+# Lint 配置更新
+
+为了保证代码质量，我们推荐使用 lint 相关的工具对代码进行检测，同时为了降低常规 lint 工具的使用成本，我们推荐使用 [@iceworks/spec](https://github.com/ice-lab/spec) 这个 npm 包，不但基础的 lint 规则与[阿里巴巴前端规范](https://f2e.alibaba-inc.com/specification/)保持一致，同时还加入了适合您项目的最佳实践。
+
+更新原因：
+
+- 享用最新的阿里巴巴前端规范和最佳实践，统一 lint 规范保证代码质量。
+- 与 AppWorks 代码检测体系保持一致，保证项目稳定高效迭代。
+
+若您的项目依赖中没有 `@iceworks/spec` 时，建议运行此 CodeMod
+
+### 修改 package.json 依赖
+
+1. 安装 @iceworks/spec 及 lint 相关工具库（eslint，stylelint 及 prettier）。
+2. 删除 eslint 及 stylelint 原先的配置和插件。（不同版本的插件和配置会影响 lint 工具的运行，@iceworks/spec 已内置相关依赖，您无需关注）。
+3. 增加 script lint 相关脚本。
+
+```diff
+{
+  scripts:{
++   "eslint": "eslint --fix --ext  .js,.jsx,.ts,.tsx ./",
++   "stylelint": "stylelint "**/*.{css,scss,less}"",
++   "prettier": "prettier **/* --write",
++   "lint": "npm run eslint && npm run stylelint",
+  },
+  devDependencies:{
+-   "eslint-plugin-import": "^2.3.30",
++   "@iceworks/spec": "^1.0.0",
++   "eslint": "^7.22.0",
++   "stylelint": "^7.22.0",
++   "prettier": "^2.1.0",
+  }
+}
+```
+
+### 修改 lint 配置
+
+1. 增加 lint ignore 相关文件。
+2. 保留您的 lint 配置，并更新使用 `@iceworks/spec`。
+
+您的原先 .eslintrc.{js,json} 和 .stylelintrc.{js,json} 自定义的配置将会被保留。比如：
+
+```diff
+- const { eslint, deepmerge } = require('@ice/spec');
++ const { getESLintConfig } = require('@iceworks/spec');
+
+- module.exports = deepmerge(eslint, {
++ module.exports = getESLintConfig('rax', {  
+  rules: {
+    s: 1
+  },
+});
+```
+
+如项目工程升级过程中遇到问题请通过 [issue](https://github.com/appworks-lab/codemod) 进行反馈。

--- a/transforms/docs/plugin-rax-component-to-component.md
+++ b/transforms/docs/plugin-rax-component-to-component.md
@@ -66,4 +66,4 @@
 1. 小程序相关的模版代码将自动生成，原 miniapp 目录移除，如果有自定义小程序 props 属性的测试需求，可以增加 miniapp-demo 目录
 2. demo 目录下不再支持 index.j|tsx 文件，demo 文件均采用 \*.md
 
-如组件工程迁移过程中遇到问题请通过 [issue](https://github.com/ice-lab/iceworks-cli/issues) 进行反馈。
+如组件工程迁移过程中遇到问题请通过 [issue](https://github.com/appworks-lab/codemod) 进行反馈。

--- a/transforms/lint-config-to-spec.js
+++ b/transforms/lint-config-to-spec.js
@@ -162,7 +162,7 @@ module.exports = (fileInfo, api, options) => {
         }
 
         // 3. generate files
-        if (generateFiles) {
+        if (options.dry !== true && generateFiles) {
           fs.writeFileSync(path.join(dir, generateFiles.ignoreFile), IGNORE_FILE_TEMPLATE, 'utf8');
           fs.writeFileSync(path.join(dir, generateFiles.configFile), ejs.render(generateFiles.configFileTemplate, { ruleKey, eslintRuleKey, customConfig }), 'utf8');
         }

--- a/transforms/lint-config-to-spec.js
+++ b/transforms/lint-config-to-spec.js
@@ -20,7 +20,7 @@ const LIB_CONFIG = {
         'const { getESLintConfig } = require(\'@iceworks/spec\');\n' +
         '\n' +
         '// https://www.npmjs.com/package/@iceworks/spec\n' +
-        'module.exports = getESLintConfig(\'<%= ruleKey %>\'<% if (customConfig) { %>, <%- JSON.stringify(customConfig, null, \'  \') %><% } %>);\n',
+        'module.exports = getESLintConfig(\'<%= eslintRuleKey %>\'<% if (customConfig) { %>, <%- JSON.stringify(customConfig, null, \'  \') %><% } %>);\n',
     },
   },
   stylelint: {
@@ -39,7 +39,7 @@ const LIB_CONFIG = {
         'const { getStylelintConfig } = require(\'@iceworks/spec\');\n' +
         '\n' +
         '// https://www.npmjs.com/package/@iceworks/spec\n' +
-        'module.exports = getStylelintConfig(\'<%= eslintRuleKey %>\'<% if (customConfig) { %>, <%- JSON.stringify(customConfig, null, \'  \') %><% } %>);\n',
+        'module.exports = getStylelintConfig(\'<%= ruleKey %>\'<% if (customConfig) { %>, <%- JSON.stringify(customConfig, null, \'  \') %><% } %>);\n',
     },
   },
   prettier: {

--- a/transforms/lint-config-to-spec.js
+++ b/transforms/lint-config-to-spec.js
@@ -1,0 +1,175 @@
+// Use @iceworks/spec update lint configs
+const fs = require('fs');
+const path = require('path');
+const ejs = require('ejs');
+
+const LIB_CONFIG = {
+  eslint: {
+    processPackageJson: {
+      recommendedVersion: '^7.22.0',
+      removePackagesReg: /eslint-.*/g, // remove all other eslint-xx packages
+    },
+    processOriginalConfig: {
+      configFileName: '.eslintrc',
+      removeConfigKeys: ['extends', 'plugins'],
+    },
+    generateFiles: {
+      ignoreFile: '.eslintignore',
+      configFile: '.eslintrc.js',
+      configFileTemplate:
+        'const { getESLintConfig } = require(\'@iceworks/spec\');\n' +
+        '\n' +
+        '// https://www.npmjs.com/package/@iceworks/spec\n' +
+        'module.exports = getESLintConfig(\'<%= ruleKey %>\'<% if (customConfig) { %>, <%- JSON.stringify(customConfig, null, \'  \') %><% } %>);\n',
+    },
+  },
+  stylelint: {
+    processPackageJson: {
+      recommendedVersion: '^13.7.2',
+      removePackagesReg: /stylelint-.*/g, // remove all other stylelint-xx packages
+    },
+    processOriginalConfig: {
+      configFileName: '.stylelintrc',
+      removeConfigKeys: ['extends', 'plugins'],
+    },
+    generateFiles: {
+      ignoreFile: '.stylelintignore',
+      configFile: '.stylelintrc.js',
+      configFileTemplate:
+        'const { getStylelintConfig } = require(\'@iceworks/spec\');\n' +
+        '\n' +
+        '// https://www.npmjs.com/package/@iceworks/spec\n' +
+        'module.exports = getStylelintConfig(\'<%= eslintRuleKey %>\'<% if (customConfig) { %>, <%- JSON.stringify(customConfig, null, \'  \') %><% } %>);\n',
+    },
+  },
+  prettier: {
+    processPackageJson: {
+      recommendedVersion: '^2.1.0',
+      configFileReg: /\.prettierrc\.(js|json)$/, // only process js and json file
+    },
+    generateFiles: {
+      ignoreFile: '.prettierignore',
+      configFile: '.prettierrc.js',
+      configFileTemplate:
+        'const { getPrettierConfig } = require(\'@iceworks/spec\');\n' +
+        '\n' +
+        '// https://www.npmjs.com/package/@iceworks/spec\n' +
+        'module.exports = getPrettierConfig(\'<%= ruleKey %>\'<% if (customConfig) { %>, <%- JSON.stringify(customConfig, null, \'  \') %><% } %>);\n',
+    },
+  },
+};
+
+const IGNORE_FILE_TEMPLATE = `
+node_modules/
+lib/
+dist/
+build/
+tests/
+coverage/
+demo/
+es/
+.rax/
+.ice/
+`;
+
+const SCRIPT_TEMPLATE = {
+  eslint: 'eslint --fix --ext  .js,.jsx,.ts,.tsx ./',
+  stylelint: 'stylelint "**/*.{css,scss,less}"',
+  prettier: 'prettier **/* --write',
+  lint: 'npm run eslint && npm run stylelint',
+};
+
+module.exports = (fileInfo, api, options) => {
+  const j = api.jscodeshift;
+  const dir = path.dirname(fileInfo.path);
+  const basename = path.basename(fileInfo.path);
+
+  const { projectType, projectLanguageType } = options;
+
+  let ruleKey = '';
+  let eslintRuleKey = '';
+  let customConfig;
+
+  // 'unknown' | 'rax' | 'react' | 'vue';
+  if (projectType === 'unknown') {
+    ruleKey = 'common';
+  } else {
+    ruleKey = projectType;
+  }
+
+  eslintRuleKey = ruleKey;
+  if (projectLanguageType === 'ts') {
+    // 'ts' | 'js';
+    eslintRuleKey += '-ts';
+  }
+
+  // Only process once
+  if (basename === 'package.json') {
+    const config = JSON.parse(fileInfo.source);
+    const { scripts = {}, devDependencies = {} } = config;
+
+    // if @iceworks/spec not exists, then run.
+    if (!devDependencies['@iceworks/spec']) {
+      Object.assign(scripts, SCRIPT_TEMPLATE);
+      devDependencies['@iceworks/spec'] = '^1.0.0';
+
+      Object.keys(LIB_CONFIG).forEach((key) => {
+        const libConfig = LIB_CONFIG[key];
+        const { processPackageJson, processOriginalConfig, generateFiles } = libConfig;
+
+        // 1. process package.json
+        if (processPackageJson) {
+          devDependencies[key] = processPackageJson.recommendedVersion;
+          if (processPackageJson.removePackagesReg) {
+            Object.keys(devDependencies).forEach((k) => {
+              if (processPackageJson.removePackagesReg.test(k)) {
+                delete devDependencies[k];
+              }
+            });
+          }
+        }
+
+        // 2. process original config
+        if (processOriginalConfig) {
+          let originalConfig;
+          // Only process js and json config file
+          const jsConfigFile = path.join(dir, `${processOriginalConfig.configFileName}.js`);
+          const jsonConfigFile = path.join(dir, `${processOriginalConfig.configFileName}.json`);
+
+          if (fs.existsSync(jsConfigFile)) {
+            const source = fs.readFileSync(jsConfigFile, 'utf8');
+            // Only find fist level object
+            let isFirstLevelObject = true;
+            j(source).find(j.ObjectExpression).forEach((p) => {
+              if (!isFirstLevelObject) return;
+              const { start, end } = p.node;
+              // eslint-disable-next-line
+              originalConfig = eval(`(${source.substring(start, end)})`);
+              isFirstLevelObject = false;
+            });
+          } else if (fs.existsSync(jsonConfigFile)) {
+            const source = fs.readFileSync(jsConfigFile, 'utf8');
+            originalConfig = JSON.parse(source);
+          }
+
+          // Set new custom config
+          if (originalConfig) {
+            processOriginalConfig.removeConfigKeys.forEach((k) => {
+              delete originalConfig[k];
+            });
+            customConfig = originalConfig;
+          }
+        }
+
+        // 3. generate files
+        if (generateFiles) {
+          fs.writeFileSync(path.join(dir, generateFiles.ignoreFile), IGNORE_FILE_TEMPLATE, 'utf8');
+          fs.writeFileSync(path.join(dir, generateFiles.configFile), ejs.render(generateFiles.configFileTemplate, { ruleKey, eslintRuleKey, customConfig }), 'utf8');
+        }
+      });
+      return JSON.stringify(config, null, '  ');
+    }
+    return null;
+  }
+  return null;
+};


### PR DESCRIPTION
# Lint 配置更新

为了保证代码质量，我们推荐使用 lint 相关的工具对代码进行检测，同时为了降低常规 lint 工具的使用成本，我们推荐使用 [@iceworks/spec](https://github.com/ice-lab/spec) 这个 npm 包，不但基础的 lint 规则与[阿里巴巴前端规范](https://f2e.alibaba-inc.com/specification/)保持一致，同时还加入了适合您项目的最佳实践。

更新原因：

- 享用最新的阿里巴巴前端规范和最佳实践，统一 lint 规范保证代码质量。
- 与 AppWorks 代码检测体系保持一致，保证项目稳定高效迭代。

若您的项目依赖中没有 `@iceworks/spec` 时，建议运行此 CodeMod

### 修改 package.json 依赖

1. 安装 @iceworks/spec 及 lint 相关工具库（eslint，stylelint 及 prettier）。
2. 删除 eslint 及 stylelint 原先的配置和插件。（不同版本的插件和配置会影响 lint 工具的运行，@iceworks/spec 已内置相关依赖，您无需关注）。
3. 增加 script lint 相关脚本。

```diff
{
  scripts:{
+   "eslint": "eslint --fix --ext  .js,.jsx,.ts,.tsx ./",
+   "stylelint": "stylelint "**/*.{css,scss,less}"",
+   "prettier": "prettier **/* --write",
+   "lint": "npm run eslint && npm run stylelint",
  },
  devDependencies:{
-   "eslint-plugin-import": "^2.3.30",
+   "@iceworks/spec": "^1.0.0",
+   "eslint": "^7.22.0",
+   "stylelint": "^7.22.0",
+   "prettier": "^2.1.0",
  }
}
```

### 修改 lint 配置

1. 增加 lint ignore 相关文件。
2. 保留您的 lint 配置，并更新使用 `@iceworks/spec`。

您的原先 .eslintrc.{js,json} 和 .stylelintrc.{js,json} 自定义的配置将会被保留。比如：

```diff
- const { eslint, deepmerge } = require('@ice/spec');
+ const { getESLintConfig } = require('@iceworks/spec');

- module.exports = deepmerge(eslint, {
+ module.exports = getESLintConfig('rax', {  
  rules: {
    s: 1
  },
});
```
